### PR TITLE
Replace basestring with future.utils.string_types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ doc/~thumbnails.zip
 *.bak
 *.swp
 *.orig
+.eggs/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ doc/~thumbnails.zip
 /lib/taurus.egg-info
 *.bak
 *.swp
+*.orig

--- a/lib/taurus/__init__.py
+++ b/lib/taurus/__init__.py
@@ -30,7 +30,7 @@ from builtins import object
 from .core import release as __R
 
 
-class Release(object):
+class Release:
     pass
 
 for attr, value in __R.__dict__.items():

--- a/lib/taurus/__init__.py
+++ b/lib/taurus/__init__.py
@@ -33,8 +33,9 @@ from .core import release as __R
 class Release(object):
     pass
 
-for key, value in list(__R.__dict__.items()):
-    setattr(Release, key, value)
+for attr, value in __R.__dict__.items():
+	setattr(Release, attr, value)
+
 Release.__doc__ = __R.__doc__
 
 from .core.taurushelper import *

--- a/lib/taurus/console/list.py
+++ b/lib/taurus/console/list.py
@@ -36,6 +36,8 @@ import textwrap
 import collections
 import operator
 
+from future.utils import string_types
+
 from .enums import Alignment
 
 
@@ -64,7 +66,7 @@ class List(list):
             self.append(header)
 
     def setHeaderSeparator(self, header_separator):
-        if isinstance(header_separator, (str, str)):
+        if isinstance(header_separator, string_types):
             header_separator = self.col_nb * [header_separator]
         self.HeaderSeparator = header_separator
 
@@ -74,7 +76,7 @@ class List(list):
     header_separator = property(getHeaderSeparator, setHeaderSeparator)
 
     def setRowSeparator(self, row_separator):
-        if isinstance(row_separator, (str, str)):
+        if isinstance(row_separator, string_types):
             row_separator = self.col_nb * [row_separator]
         self.RowSeparator = row_separator
 

--- a/lib/taurus/core/evaluation/evalvalidator.py
+++ b/lib/taurus/core/evaluation/evalvalidator.py
@@ -30,7 +30,7 @@ __all__ = ['EvaluationDeviceNameValidator',
 import re
 import hashlib
 
-from future.util import string_types
+from future.utils import string_types
 
 import taurus
 from taurus import isValidName, debug
@@ -253,7 +253,7 @@ class EvaluationAttributeNameValidator(TaurusAttributeNameValidator):
                           string containing a semi-colon separated list of
                           symbol=value pairs can also be passed.
         '''
-        if isinstance(substmap, (str, unicode)):
+        if isinstance(substmap, string_types):
             substmap = dict(K_EQUALS_V_RE.findall(substmap))
         ret = expr
         protected = {}

--- a/lib/taurus/core/evaluation/evalvalidator.py
+++ b/lib/taurus/core/evaluation/evalvalidator.py
@@ -260,7 +260,7 @@ class EvaluationAttributeNameValidator(TaurusAttributeNameValidator):
 
         # temporarily replace the text within quotes by hash-based placeholders
         for s in QUOTED_TEXT_RE.findall(expr):
-            placeholder = hashlib.md5(s).hexdigest()
+            placeholder = hashlib.md5(s.encode('utf-8')).hexdigest()
             protected[placeholder] = s
             ret = re.sub(s, placeholder, ret)
 

--- a/lib/taurus/core/evaluation/evalvalidator.py
+++ b/lib/taurus/core/evaluation/evalvalidator.py
@@ -30,6 +30,8 @@ __all__ = ['EvaluationDeviceNameValidator',
 import re
 import hashlib
 
+from future.util import string_types
+
 import taurus
 from taurus import isValidName, debug
 from taurus.core import TaurusElementType
@@ -251,7 +253,7 @@ class EvaluationAttributeNameValidator(TaurusAttributeNameValidator):
                           string containing a semi-colon separated list of
                           symbol=value pairs can also be passed.
         '''
-        if isinstance(substmap, str):
+        if isinstance(substmap, (str, unicode)):
             substmap = dict(K_EQUALS_V_RE.findall(substmap))
         ret = expr
         protected = {}

--- a/lib/taurus/core/resource/resfactory.py
+++ b/lib/taurus/core/resource/resfactory.py
@@ -34,6 +34,8 @@ import imp
 import operator
 import types
 
+from future.utils import string_types
+
 from taurus.core.taurushelper import Manager
 from taurus.core.util.singleton import Singleton
 from taurus.core.util.log import Logger

--- a/lib/taurus/core/tango/test/res/TangoSchemeTest
+++ b/lib/taurus/core/tango/test/res/TangoSchemeTest
@@ -22,6 +22,8 @@
 # along with Taurus.  If not, see <http://www.gnu.org/licenses/>.
 ##
 #############################################################################
+from __future__ import print_function
+
 import numpy
 from time import (time, sleep)
 
@@ -495,7 +497,7 @@ class TangoSchemeTest(Device):
                                        AttrQuality.ATTR_VALID)
                 sleep(self.sleeptime)
             except Exception as e:
-                print 'Exception in update loop', e
+                print('Exception in update loop', e)
                 sleep(1)
 
     def init_device(self):

--- a/lib/taurus/core/test/test_taurushelper.py
+++ b/lib/taurus/core/test/test_taurushelper.py
@@ -255,7 +255,7 @@ class AuthorityTestCase(unittest.TestCase):
 @insertTest(helper_name='get_object', name='eval:@Foo')
 @insertTest(helper_name='get_object', name='eval://dev=Foo')
 @insertTest(helper_name='get_object', name='eval:@datetime.*')
-@insertTest(helper_name='get_object', name='eval:@d=datetime.date(2017,03,29)')
+@insertTest(helper_name='get_object', name='eval:@d=datetime.date(2017,3,29)')
 class DeviceTestCase(unittest.TestCase):
     '''TestCase for the taurus.Device helper'''
 
@@ -404,7 +404,7 @@ class DeviceTestCase(unittest.TestCase):
                           label='Q("1km").to("mm").magnitude',
                           type=DataType.Float))
 @insertTest(helper_name='read_attr',
-            name='eval:@d=datetime.date(1931,04,14)/d.isoformat()',
+            name='eval:@d=datetime.date(1931,4,14)/d.isoformat()',
             expected=dict(rvalue='1931-04-14', value='1931-04-14',
                           wvalue=None, w_value=None,
                           label='d.isoformat()',

--- a/lib/taurus/core/util/codecs.py
+++ b/lib/taurus/core/util/codecs.py
@@ -76,9 +76,17 @@ import copy
 import struct
 import numpy
 
+from future.utils import PY2
+
 from .singleton import Singleton
 from .log import Logger
 from .containers import CaselessDict
+
+
+if PY2:
+    buffer_types = buffer, memoryview, 
+else:
+    buffer_types = memoryview,
 
 
 class Codec(Logger):
@@ -280,8 +288,8 @@ class PickleCodec(Codec):
             return data
         format = data[0].partition('_')[2]
 
-        if isinstance(data[1], buffer):
-            data = data[0], str(data[1])
+        if isinstance(data[1], buffer_types):
+            data = data[0], bytes(data[1])
 
         return format, pickle.loads(data[1])
 
@@ -340,7 +348,7 @@ class JSONCodec(Codec):
 
         ensure_ascii = kwargs.pop('ensure_ascii', False)
 
-        if isinstance(data[1], buffer):
+        if isinstance(data[1], buffer_types):
             data = data[0], str(data[1])
 
         data = json.loads(data[1])

--- a/lib/taurus/core/util/containers.py
+++ b/lib/taurus/core/util/containers.py
@@ -41,6 +41,8 @@ __all__ = ["CaselessList", "CaselessDict", "CaselessWeakValueDict", "LoopList",
 
 __docformat__ = "restructuredtext"
 
+from future.utils import string_types
+
 import copy
 import collections
 import time
@@ -65,7 +67,7 @@ class CaselessList(list):
     def __init__(self, inlist=[]):
         list.__init__(self)
         for entry in inlist:
-            if not isinstance(entry, basestring):
+            if not isinstance(entry, string_types):
                 raise TypeError('Members of this object must be strings. '
                                 'You supplied \"%s\" which is \"%s\"' %
                                 (entry, type(entry)))
@@ -79,7 +81,7 @@ class CaselessList(list):
     def findentry(self, item):
         """A caseless way of checking if an item is in the list or not.
         It returns None or the entry."""
-        if not isinstance(item, basestring):
+        if not isinstance(item, string_types):
             raise TypeError('Members of this object must be strings. '
                             'You supplied \"%s\"' % type(item))
         for entry in self:
@@ -116,7 +118,7 @@ class CaselessList(list):
 
     def append(self, item):
         """Adds an item to the list and checks it's a string."""
-        if not isinstance(item, basestring):
+        if not isinstance(item, string_types):
             raise TypeError('Members of this object must be strings. '
                             'You supplied \"%s\"' % type(item))
         list.append(self, item)
@@ -128,7 +130,7 @@ class CaselessList(list):
             raise TypeError('You can only extend lists with lists. '
                             'You supplied \"%s\"' % type(item))
         for entry in item:
-            if not isinstance(entry, basestring):
+            if not isinstance(entry, string_types):
                 raise TypeError('Members of this object must be strings. '
                                 'You supplied \"%s\"' % type(entry))
             list.append(self, entry)
@@ -136,7 +138,7 @@ class CaselessList(list):
     def count(self, item):
         """Counts references to 'item' in a caseless manner.
         If item is not a string it will always return 0."""
-        if not isinstance(item, basestring):
+        if not isinstance(item, string_types):
             return 0
         count = 0
         for entry in self:
@@ -155,7 +157,7 @@ class CaselessList(list):
             maxindex = len(self)
         minindex = max(0, minindex) - 1
         maxindex = min(len(self), maxindex)
-        if not isinstance(item, basestring):
+        if not isinstance(item, string_types):
             raise TypeError('Members of this object must be strings. '
                             'You supplied \"%s\"' % type(item))
         index = minindex
@@ -168,7 +170,7 @@ class CaselessList(list):
     def insert(self, i, x):
         """s.insert(i, x) same as s[i:i] = [x]
         Raises TypeError if x isn't a string."""
-        if not isinstance(x, basestring):
+        if not isinstance(x, string_types):
             raise TypeError('Members of this object must be strings. '
                             'You supplied \"%s\"' % type(x))
         list.insert(self, i, x)
@@ -182,7 +184,7 @@ class CaselessList(list):
         the same length as the slice object requires.
         """
         if isinstance(index, int):
-            if not isinstance(value, basestring):
+            if not isinstance(value, string_types):
                 raise TypeError('Members of this object must be strings. '
                                 'You supplied \"%s\"' % type(value))
             list.__setitem__(self, index, value)
@@ -191,7 +193,7 @@ class CaselessList(list):
                 raise TypeError(
                     'Value given to set slice is not a sequence object.')
             for entry in value:
-                if not isinstance(entry, basestring):
+                if not isinstance(entry, string_types):
                     raise TypeError('Members of this object must be strings. '
                                     'You supplied \"%s\"' % type(entry))
             list.__setitem__(self, index, value)
@@ -201,7 +203,7 @@ class CaselessList(list):
     def __setslice__(self, i, j, sequence):
         """Called to implement assignment to self[i:j]."""
         for entry in sequence:
-            if not isinstance(entry, basestring):
+            if not isinstance(entry, string_types):
                 raise TypeError('Members of this object must be strings. '
                                 'You supplied \"%s\"' % type(entry))
         list.__setslice__(self, i, j, sequence)

--- a/lib/taurus/core/util/containers.py
+++ b/lib/taurus/core/util/containers.py
@@ -306,7 +306,7 @@ class CaselessDict(dict):
 class CaselessWeakValueDict(weakref.WeakValueDictionary):
 
     def __init__(self, other=None):
-        weakref.WeakValueDictionary.__init__(self)
+        weakref.WeakValueDictionary.__init__(self, other)
         if other:
             # Doesn't do keyword args
             if isinstance(other, dict):
@@ -341,8 +341,9 @@ class CaselessWeakValueDict(weakref.WeakValueDictionary):
 
     def update(self, other):
         """overwritten from :meth:`weakref.WeakValueDictionary.update`"""
-        for k, v in list(other.items()):
-            weakref.WeakValueDictionary.__setitem__(self, k.lower(), v)
+        if other:
+            for k, v in list(other.items()):
+                weakref.WeakValueDictionary.__setitem__(self, k.lower(), v)
 
     def fromkeys(self, iterable, value=None):
         d = CaselessWeakValueDict()

--- a/lib/taurus/core/util/enumeration.py
+++ b/lib/taurus/core/util/enumeration.py
@@ -39,6 +39,8 @@ __all__ = ["EnumException", "Enumeration"]
 
 __docformat__ = "restructuredtext"
 
+from future.utils import string_types
+
 
 class EnumException(Exception):
     """Exception thrown by :class:`Enumeration` when trying to declare an
@@ -97,7 +99,7 @@ class Enumeration(object):
                     raise EnumException(
                         "flagable enum does not accept tuple items")
                 x, i = x
-                if not isinstance(x, (str, str)):
+                if not isinstance(x, string_types):
                     raise EnumException("enum name is not a string: " + str(x))
                 if not isinstance(i, (int, int)):
                     raise EnumException(
@@ -113,7 +115,7 @@ class Enumeration(object):
                 reverseLookup[i] = x
         for x in enumList:
             if not isinstance(x, tuple):
-                if not isinstance(x, (str, str)):
+                if not isinstance(x, string_types):
                     raise EnumException("enum name is not a string: " + str(x))
                 if x in uniqueNames:
                     raise EnumException("enum name is not unique: " + str(x))
@@ -145,15 +147,15 @@ class Enumeration(object):
         return n
 
     def __contains__(self, i):
-        if isinstance(i, (int, int)):
+        if isinstance(i, (int, long)):
             return i in self.reverseLookup
-        elif isinstance(i, (str, str)):
+        elif isinstance(i, string_types):
             return i in self.lookup
 
     def __getitem__(self, i):
         if isinstance(i, (int, int)):
             return self.whatis(i)
-        elif isinstance(i, (str, str)):
+        elif isinstance(i, string_types):
             return self.lookup[i]
 
     def __getattr__(self, attr):

--- a/lib/taurus/core/util/enumeration.py
+++ b/lib/taurus/core/util/enumeration.py
@@ -39,7 +39,7 @@ __all__ = ["EnumException", "Enumeration"]
 
 __docformat__ = "restructuredtext"
 
-from future.utils import string_types
+from future.utils import integer_types, string_types
 
 
 class EnumException(Exception):
@@ -147,7 +147,7 @@ class Enumeration(object):
         return n
 
     def __contains__(self, i):
-        if isinstance(i, (int, long)):
+        if isinstance(i, integer_types):
             return i in self.reverseLookup
         elif isinstance(i, string_types):
             return i in self.lookup

--- a/lib/taurus/core/util/log.py
+++ b/lib/taurus/core/util/log.py
@@ -433,6 +433,8 @@ class _Logger(logging.Logger):
             if filename in (_srcfile, logging._srcfile):
                 f = f.f_back
                 continue
+            
+            sinfo = None
             if stack_info:
                 sio = io.StringIO()
                 sio.write('Stack (most recent call last):\n')
@@ -441,7 +443,7 @@ class _Logger(logging.Logger):
                 if sinfo[-1] == '\n':
                     sinfo = sinfo[:-1]
                 sio.close()
-            rv = (co.co_filename, f.f_lineno, co.co_name, stack_info)
+            rv = (co.co_filename, f.f_lineno, co.co_name, sinfo)
             break
         return rv
 

--- a/lib/taurus/core/util/log.py
+++ b/lib/taurus/core/util/log.py
@@ -899,10 +899,9 @@ class Logger(Object):
                 raise Exception(msg)
             if _DEPRECATION_COUNT[msg] > _MAX_DEPRECATIONS_LOGGED:
                 return
-
         if _callerinfo is None:
             _callerinfo = self.log_obj.findCaller()
-        filename, lineno, fname, sinfo = _callerinfo
+        filename, lineno, fname  = _callerinfo[0], _callerinfo[1], _callerinfo[2]
         depr_msg = warnings.formatwarning(
             msg, DeprecationWarning, filename, lineno)
         self.log_obj.warning(depr_msg, **kw)

--- a/lib/taurus/core/util/log.py
+++ b/lib/taurus/core/util/log.py
@@ -39,6 +39,7 @@ __all__ = ["LogIt", "TraceIt", "DebugIt", "InfoIt", "WarnIt", "ErrorIt",
 
 __docformat__ = "restructuredtext"
 
+import io
 import os
 import sys
 import logging.handlers
@@ -414,6 +415,7 @@ class LogExceptHook(BaseExceptHook):
 
 class _Logger(logging.Logger):
 
+
     def findCaller(self, stack_info=False):
         """
         Find the stack frame of the caller so that we can note the source
@@ -424,13 +426,21 @@ class _Logger(logging.Logger):
         # IronPython isn't run with -X:Frames.
         if f is not None:
             f = f.f_back
-        rv = "(unknown file)", 0, "(unknown function)", stack_info
+        rv = "(unknown file)", 0, "(unknown function)", None
         while hasattr(f, "f_code"):
             co = f.f_code
             filename = os.path.normcase(co.co_filename)
             if filename in (_srcfile, logging._srcfile):
                 f = f.f_back
                 continue
+            if stack_info:
+                sio = io.StringIO()
+                sio.write('Stack (most recent call last):\n')
+                traceback.print_stack(f, file=sio)
+                sinfo = sio.getvalue()
+                if sinfo[-1] == '\n':
+                    sinfo = sinfo[:-1]
+                sio.close()
             rv = (co.co_filename, f.f_lineno, co.co_name, stack_info)
             break
         return rv
@@ -890,7 +900,7 @@ class Logger(Object):
 
         if _callerinfo is None:
             _callerinfo = self.log_obj.findCaller()
-        filename, lineno, _, _ = _callerinfo
+        filename, lineno, fname, sinfo = _callerinfo
         depr_msg = warnings.formatwarning(
             msg, DeprecationWarning, filename, lineno)
         self.log_obj.warning(depr_msg, **kw)

--- a/lib/taurus/external/qt/QtCore.py
+++ b/lib/taurus/external/qt/QtCore.py
@@ -26,6 +26,7 @@
 """This module exposes QtCore module"""
 
 from builtins import object
+from future.utils import string_types
 from taurus.external.qt import API_NAME
 
 __backend = API_NAME
@@ -66,7 +67,7 @@ def __from_qvariant_1(qobj=None, convfunc=None):
             return qobj.toInt()[0]
         elif convfunc is float:
             return qobj.toDouble()[0]
-    elif isinstance(convfunc, (str, str)):
+    elif isinstance(convfunc, string_types):
         return getattr(qobj, convfunc)()
 
 

--- a/lib/taurus/qt/qtcore/configuration/configuration.py
+++ b/lib/taurus/qt/qtcore/configuration/configuration.py
@@ -36,6 +36,8 @@ __all__ = ["configurableProperty", "BaseConfigurableClass"]
 
 __docformat__ = 'restructuredtext'
 
+from future.utils import string_types
+
 
 class configurableProperty(object):
     '''A dummy class used to handle properties with the configuration API
@@ -53,7 +55,7 @@ class configurableProperty(object):
 
     def createConfig(self, allowUnpickable=False):
         '''returns value returned by the fget function of this property. the allowUnpickable parameter is ignored'''
-        if isinstance(self.fget, basestring):  # fget is not a method but a method name...
+        if isinstance(self.fget, string_types):  # fget is not a method but a method name...
             result = getattr(self._obj, self.fget)()
         else:
             result = self.fget()
@@ -61,7 +63,7 @@ class configurableProperty(object):
 
     def applyConfig(self, value, depth=-1):
         '''calls the fset function for this property with the given value. The depth parameter is ignored'''
-        if isinstance(self.fget, basestring):  # fget is not a method but a method name...
+        if isinstance(self.fget, string_types):  # fget is not a method but a method name...
             getattr(self._obj, self.fset)(value)
         else:
             self.fset(value)
@@ -353,7 +355,7 @@ class BaseConfigurableClass(object):
 
         .. seealso:: :meth:`registerConfigProperty`, :meth:`registerConfigDelegate`
         '''
-        if isinstance(item, basestring):
+        if isinstance(item, string_types):
             name = str(item)
         else:
             name = str(item.objectName())

--- a/lib/taurus/qt/qtcore/util/emitter.py
+++ b/lib/taurus/qt/qtcore/util/emitter.py
@@ -153,7 +153,7 @@ class TaurusEmitterThread(Qt.QThread):
     .. code-block:: python
 
         #Applying TaurusEmitterThread to an existing class:
-        from Queue import Queue
+        from queue import Queue
         from functools import partial
 
         def modelSetter(args):

--- a/lib/taurus/qt/qtcore/util/emitter.py
+++ b/lib/taurus/qt/qtcore/util/emitter.py
@@ -42,6 +42,8 @@ import traceback
 from functools import partial
 from collections import Iterable
 
+from future.utils import string_types
+
 import taurus
 from taurus.external.qt import Qt
 from taurus.core.util.log import Logger
@@ -55,7 +57,7 @@ from taurus.core.taurusbasetypes import SubscriptionState
 
 
 def isString(seq):
-    if isinstance(seq, basestring):
+    if isinstance(seq, string_types):
         return True  # It matches most python str-like classes
     if any(s in str(type(seq)).lower() for s in ('vector', 'array', 'list',)):
         return False

--- a/lib/taurus/qt/qtgui/application/taurusapplication.py
+++ b/lib/taurus/qt/qtgui/application/taurusapplication.py
@@ -67,6 +67,11 @@ class STD(Logger):
         self.buffer = ''
         self.log_obj.propagate = False
         self.std = std
+    
+#Trying to mimic  stderr
+    @property
+    def errors(self):
+        return self.std.errors
 
     def addLogHandler(self, handler):
         """When called, set to use a private handler and DON'T send messages

--- a/lib/taurus/qt/qtgui/application/taurusapplication.py
+++ b/lib/taurus/qt/qtgui/application/taurusapplication.py
@@ -25,9 +25,9 @@
 
 """This module provides the base
 :class:`taurus.qt.qtgui.application.TaurusApplication` class."""
-
-from builtins import str
 from __future__ import with_statement
+from builtins import str
+
 
 __all__ = ["TaurusApplication"]
 

--- a/lib/taurus/qt/qtgui/base/taurusbase.py
+++ b/lib/taurus/qt/qtgui/base/taurusbase.py
@@ -38,6 +38,7 @@ import sys
 import threading
 from types import MethodType
 
+from future.utils import string_types
 from taurus.external.qt import Qt
 from enum import Enum
 
@@ -761,7 +762,7 @@ class TaurusBaseComponent(TaurusListener, BaseConfigurableClass):
         :param kwargs: keyword arguments that will be passed to
                        :attribute:`FORMAT` if it is a callable
         """
-        if not isinstance(self.FORMAT, basestring):
+        if not isinstance(self.FORMAT, string_types):
             # unbound method to callable
             if isinstance(self.FORMAT, MethodType):
                 self.FORMAT = self.FORMAT.__func__
@@ -780,7 +781,7 @@ class TaurusBaseComponent(TaurusListener, BaseConfigurableClass):
                        "full.module.callable" format)
         """
         # Check if the format is a callable string representation
-        if isinstance(format, basestring):
+        if isinstance(format, string_types):
             try:
                 moduleName, formatterName = format.rsplit('.', 1)
                 __import__(moduleName)
@@ -797,7 +798,7 @@ class TaurusBaseComponent(TaurusListener, BaseConfigurableClass):
         :return: (str) a string of the current format.
         It could be a python format string or a callable string representation.
         """
-        if isinstance(self.FORMAT, basestring):
+        if isinstance(self.FORMAT, string_types):
             formatter = self.FORMAT
         else:
             formatter = '{0}.{1}'.format(self.FORMAT.__module__,

--- a/lib/taurus/qt/qtgui/button/taurusbutton.py
+++ b/lib/taurus/qt/qtgui/button/taurusbutton.py
@@ -34,6 +34,8 @@ __all__ = ["TaurusLauncherButton", "TaurusCommandButton", "TaurusLockButton"]
 
 __docformat__ = 'restructuredtext'
 
+from future.utils import string_types
+
 from taurus.external.qt import Qt
 from taurus.core.taurusbasetypes import LockStatus, TaurusLockInfo
 from taurus.core.taurusdevice import TaurusDevice
@@ -448,7 +450,7 @@ class TaurusCommandButton(Qt.QPushButton, TaurusBaseWidget):
                            quotes will be removed and the quoted text will not
                            be splitted.
         '''
-        if isinstance(parameters, (basestring, Qt.QString)):
+        if isinstance(parameters, string_types+ (Qt.QString,)):
             parameters = str(parameters).strip()
             if parameters[0] in ('"', "'") and parameters[0] == parameters[-1]:
                 parameters = [parameters[1:-1]]

--- a/lib/taurus/qt/qtgui/compact/abstractswitcher.py
+++ b/lib/taurus/qt/qtgui/compact/abstractswitcher.py
@@ -31,6 +31,8 @@ __all__ = ["TaurusReadWriteSwitcher"]
 
 __docformat__ = 'restructuredtext'
 
+from future.utils import string_types
+
 from taurus.external.qt import Qt
 from taurus.qt.qtgui.container import TaurusWidget
 from taurus.qt.qtgui.base import TaurusBaseWritableWidget
@@ -158,7 +160,7 @@ class TaurusReadWriteSwitcher(TaurusWidget):
                 shortcuts.append(Qt.QKeySequence(e))
             elif isinstance(e, Qt.QEvent.Type):
                 eventTypes.append(e)
-            elif isinstance(e, (basestring, Qt.QString)):
+            elif isinstance(e, string_types +(Qt.QString,)):
                 signals.append(e)
             else:
                 raise TypeError('Unsupported trigger type: %s' % repr(type(e)))

--- a/lib/taurus/qt/qtgui/container/taurusmainwindow.py
+++ b/lib/taurus/qt/qtgui/container/taurusmainwindow.py
@@ -38,6 +38,8 @@ __docformat__ = 'restructuredtext'
 import os
 import sys
 
+from future.utils import string_types
+
 from taurus import tauruscustomsettings
 from taurus.core.util import deprecation_decorator
 from taurus.external.qt import Qt
@@ -57,7 +59,7 @@ class CommandArgsLineEdit(Qt.QLineEdit):
         self.textEdited.connect(self.setCmdText)
 
     def setCmdText(self, cmdargs):
-        if not isinstance(cmdargs, (basestring, Qt.QString)):
+        if not isinstance(cmdargs, string_types + (Qt.QString,)):
             cmdargs = " ".join(cmdargs)
         self.setText(cmdargs)
         self._extapp.setCmdArgs(self.getCmdArgs(), False)

--- a/lib/taurus/qt/qtgui/extra_guiqwt/plot.py
+++ b/lib/taurus/qt/qtgui/extra_guiqwt/plot.py
@@ -33,6 +33,7 @@ __all__ = ["TaurusCurveDialog", "TaurusTrendDialog", "TaurusImageDialog"]
 
 import copy
 
+from future.utils import string_types
 from guiqwt.plot import ImageDialog, CurveDialog
 
 import taurus.core
@@ -85,7 +86,7 @@ class TaurusCurveDialog(CurveDialog, TaurusBaseWidget):
 
     def _splitModel(self, modelNames):
         '''convert str to list if needed (commas and whitespace are considered as separators)'''
-        if isinstance(modelNames, (basestring, Qt.QString)):
+        if isinstance(modelNames, string_types + (Qt.QString,)):
             modelNames = str(modelNames).replace(',', ' ')
             modelNames = modelNames.split()
         return modelNames
@@ -240,7 +241,7 @@ class TaurusTrendDialog(CurveDialog, TaurusBaseWidget):
 
     def _splitModel(self, modelNames):
         '''convert str to list if needed (commas and whitespace are considered as separators)'''
-        if isinstance(modelNames, (basestring, Qt.QString)):
+        if isinstance(modelNames, strin_types + (Qt.QString,)):
             modelNames = str(modelNames).replace(',', ' ')
             modelNames = modelNames.split()
         return modelNames

--- a/lib/taurus/qt/qtgui/graphic/jdraw/jdraw_view.py
+++ b/lib/taurus/qt/qtgui/graphic/jdraw/jdraw_view.py
@@ -34,6 +34,9 @@ __docformat__ = 'restructuredtext'
 
 import os
 import traceback
+
+from future.utils import string_types
+
 import taurus
 from taurus.external.qt import Qt
 from taurus.core.taurusbasetypes import TaurusElementType
@@ -443,7 +446,7 @@ class TaurusJDrawSynopticsView(Qt.QGraphicsView, TaurusBaseWidget):
     model = Qt.pyqtProperty("QString", getModel, setModel)
 
     def setSelectionStyle(self, selectionStyle):
-        if isinstance(selectionStyle, (Qt.QString, basestring)):
+        if isinstance(selectionStyle, (Qt.QString, string_types)):
             selectionStyle = str(selectionStyle).upper()
             try:
                 selectionStyle = SynopticSelectionStyle[selectionStyle]

--- a/lib/taurus/qt/qtgui/graphic/jdraw/jdraw_view.py
+++ b/lib/taurus/qt/qtgui/graphic/jdraw/jdraw_view.py
@@ -446,7 +446,7 @@ class TaurusJDrawSynopticsView(Qt.QGraphicsView, TaurusBaseWidget):
     model = Qt.pyqtProperty("QString", getModel, setModel)
 
     def setSelectionStyle(self, selectionStyle):
-        if isinstance(selectionStyle, (Qt.QString, string_types)):
+        if isinstance(selectionStyle,  string_types + (Qt.QString,)):
             selectionStyle = str(selectionStyle).upper()
             try:
                 selectionStyle = SynopticSelectionStyle[selectionStyle]

--- a/lib/taurus/qt/qtgui/graphic/taurusgraphic.py
+++ b/lib/taurus/qt/qtgui/graphic/taurusgraphic.py
@@ -72,7 +72,8 @@ import collections
 import operator
 import types
 
-from six.moves.queue import Queue
+from future.utils import string_types
+from queue import Queue
 
 from taurus import Manager
 from taurus.core import AttrQuality, DataType
@@ -698,7 +699,7 @@ class TaurusGraphicsScene(Qt.QGraphicsScene):
                 else:
                     if isinstance(picture, Qt.QPixmap):
                         pixmap = picture
-                    elif isinstance(picture, basestring) or isinstance(picture, Qt.QString):
+                    elif isinstance(picture, string_types) or isinstance(picture, Qt.QString):
                         picture = str(picture)
                         pixmap = Qt.QPixmap(os.path.realpath(picture))
                     SelectionMark = Qt.QGraphicsPixmapItem()

--- a/lib/taurus/qt/qtgui/graphic/taurusgraphic.py
+++ b/lib/taurus/qt/qtgui/graphic/taurusgraphic.py
@@ -72,7 +72,7 @@ import collections
 import operator
 import types
 
-import queue
+from six.moves.queue import Queue
 
 from taurus import Manager
 from taurus.core import AttrQuality, DataType
@@ -839,7 +839,7 @@ class TaurusGraphicsScene(Qt.QGraphicsScene):
     def start(self):
         if self.updateThread:
             return
-        self.updateQueue = queue.Queue()
+        self.updateQueue = Queue()
         self.updateThread = TaurusGraphicsUpdateThread(self)
         self.updateThread.start()  # Qt.QThread.HighPriority)
 

--- a/lib/taurus/qt/qtgui/panel/taurusdevicepanel.py
+++ b/lib/taurus/qt/qtgui/panel/taurusdevicepanel.py
@@ -36,6 +36,8 @@ __docformat__ = 'restructuredtext'
 import re
 import traceback
 
+from future.utils import string_types
+
 import taurus
 from taurus.external.qt import Qt
 
@@ -100,7 +102,7 @@ def str_to_filter(seq):  # TODO: Tango-centric
         f = eval(seq)
     except:
         f = seq
-    if isinstance(f, basestring):
+    if isinstance(f, string_types):
         return {'.*': [f]}
     elif isinstance(f, list):
         return {'.*': f}

--- a/lib/taurus/qt/qtgui/panel/taurusform.py
+++ b/lib/taurus/qt/qtgui/panel/taurusform.py
@@ -37,6 +37,8 @@ __docformat__ = 'restructuredtext'
 
 from datetime import datetime
 
+from future.utils import string_types
+
 from taurus.external.qt import Qt
 
 import taurus.core
@@ -169,7 +171,7 @@ class TaurusForm(TaurusWidget):
 
     def _splitModel(self, modelNames):
         '''convert str to list if needed (commas and whitespace are considered as separators)'''
-        if isinstance(modelNames, (basestring, Qt.QString)):
+        if isinstance(modelNames, string_types + (Qt.QString,)):
             modelNames = str(modelNames).replace(',', ' ')
             modelNames = modelNames.split()
         return modelNames

--- a/lib/taurus/qt/qtgui/panel/taurusinputpanel.py
+++ b/lib/taurus/qt/qtgui/panel/taurusinputpanel.py
@@ -36,6 +36,8 @@ __docformat__ = 'restructuredtext'
 import collections
 import numpy
 
+from future.utils import string_types
+
 from taurus.external.qt import Qt
 from taurus.qt.qtgui.util.ui import UILoadable
 
@@ -124,7 +126,7 @@ class TaurusInputPanel(Qt.QWidget):
         self.setText(input_data['prompt'])
 
         data_type = input_data.get('data_type', 'String')
-        is_seq = not isinstance(data_type, (str, str)) and \
+        is_seq = not isinstance(data_type, string_types) and \
             isinstance(data_type, collections.Sequence)
         if is_seq:
             panel, getter = self.create_selection_panel(input_data)
@@ -164,7 +166,7 @@ class TaurusInputPanel(Qt.QWidget):
         self._ui.inputWidget = combobox = Qt.QComboBox()
         items = input_data['data_type']
         for item in items:
-            is_seq = not isinstance(item, (str, str)) and \
+            is_seq = not isinstance(item, string_types) and \
                 isinstance(item, collections.Sequence)
             if is_seq:
                 text, userData = item
@@ -186,7 +188,7 @@ class TaurusInputPanel(Qt.QWidget):
         self._ui.inputWidget = buttongroup = Qt.QButtonGroup()
         buttongroup.setExclusive(True)
         for item in items:
-            is_seq = not isinstance(item, (str, str)) and \
+            is_seq = not isinstance(item, string_types) and \
                 isinstance(item, collections.Sequence)
             if is_seq:
                 text, userData = item
@@ -213,7 +215,7 @@ class TaurusInputPanel(Qt.QWidget):
         default_value = input_data.get('default_value')
         if default_value is None:
             default_value = ()
-        dft_is_seq = not isinstance(default_value, (str, str)) and \
+        dft_is_seq = not isinstance(default_value, string_types) and \
             isinstance(default_value, collections.Sequence)
         if not dft_is_seq:
             default_value = default_value,
@@ -222,7 +224,7 @@ class TaurusInputPanel(Qt.QWidget):
         listwidget.setSelectionMode(Qt.QAbstractItemView.MultiSelection)
 
         for item in items:
-            is_seq = not isinstance(item, (str, str)) and \
+            is_seq = not isinstance(item, string_types) and \
                 isinstance(item, collections.Sequence)
             if is_seq:
                 text, userData = item

--- a/lib/taurus/qt/qtgui/panel/taurusmodellist.py
+++ b/lib/taurus/qt/qtgui/panel/taurusmodellist.py
@@ -35,6 +35,8 @@ __all__ = ['TaurusModelModel', 'TaurusModelItem', 'TaurusModelList']
 
 import copy
 
+from future.utils import string_types
+
 from taurus.external.qt import Qt
 import taurus
 from taurus.core.taurushelper import getSchemeFromName
@@ -259,7 +261,7 @@ class TaurusModelModel(Qt.QAbstractListModel):
         for e in items:
             if isinstance(e, TaurusModelItem):
                 itemobjs.append(e)
-            elif isinstance(e, basestring):
+            elif isinstance(e, string_types):
                 itemobjs.append(TaurusModelItem(src=e))
             else:  # assuming it is a sequence of arguments that can be passed to the constructor of TaurusModelItem
                 itemobjs.append(TaurusModelItem(*e))

--- a/lib/taurus/qt/qtgui/plot/taurusplot.py
+++ b/lib/taurus/qt/qtgui/plot/taurusplot.py
@@ -45,7 +45,10 @@ import os
 import copy
 from datetime import datetime
 import time
+
 import numpy
+from future.utils import string_types
+
 from taurus.external.qt import Qt, Qwt5
 
 import taurus
@@ -3256,7 +3259,7 @@ class TaurusPlot(Qwt5.QwtPlot, TaurusBaseWidget):
     #-~-~-~-~-~-~-~-~-~-~-~-~
     def _splitModel(self, modelNames):
         '''convert str to list if needed (commas and whitespace are considered as separators)'''
-        if isinstance(modelNames, (basestring, Qt.QString)):
+        if isinstance(modelNames, string_types + (Qt.QString,)):
             modelNames = str(modelNames).replace(',', ' ')
             modelNames = modelNames.split()
         return modelNames

--- a/lib/taurus/qt/qtgui/table/qdictionary.py
+++ b/lib/taurus/qt/qtgui/table/qdictionary.py
@@ -35,7 +35,10 @@ __docformat__ = 'restructuredtext'
 
 import sys
 import taurus
+
 import numpy
+from future.utils import string_types
+
 from taurus.core.util.containers import SortedDict
 from taurus.external.qt import Qt
 from taurus.qt.qtgui.container import TaurusBaseContainer, TaurusWidget
@@ -46,7 +49,7 @@ from taurus.qt.qtcore.util.properties import join, djoin
 
 
 def isString(seq):
-    if isinstance(seq, basestring):
+    if isinstance(seq, string_types):
         return True  # It matches most python str-like classes
     if any(s in str(type(seq)).lower() for s in ('vector', 'array', 'list',)):
         return False

--- a/lib/taurus/qt/qtgui/table/taurusgrid.py
+++ b/lib/taurus/qt/qtgui/table/taurusgrid.py
@@ -47,7 +47,7 @@ __docformat__ = 'restructuredtext'
 import re
 import operator
 import traceback
-import queue
+from queue import Queue
 from functools import partial
 
 from taurus.external.qt import Qt, QtGui, QtCore
@@ -281,7 +281,7 @@ class TaurusGrid(QtGui.QFrame, TaurusBaseWidget):
         self.hideLabels = False
 
         self.defineStyle()
-        self.modelsQueue = queue.Queue()
+        self.modelsQueue = Queue()
         self.__modelsThread = None
         if not designMode:
             self.modelsThread

--- a/lib/taurus/qt/qtgui/taurusgui/taurusgui.py
+++ b/lib/taurus/qt/qtgui/taurusgui/taurusgui.py
@@ -38,6 +38,7 @@ import copy
 import weakref
 import inspect
 
+from future.utils import string_types
 from lxml import etree
 
 import taurus
@@ -1121,7 +1122,7 @@ class TaurusGui(TaurusMainWindow):
 
         # Synoptics
         SYNOPTIC = getattr(conf, 'SYNOPTIC', None)
-        if isinstance(SYNOPTIC, basestring):  # old config file style
+        if isinstance(SYNOPTIC, string_types):  # old config file style
             self.warning(
                 'Deprecated usage of SYNOPTIC keyword (now it expects a list of paths). Please update your configuration file to: "SYNOPTIC=[\'%s\']".' % SYNOPTIC)
             SYNOPTIC = [SYNOPTIC]

--- a/lib/taurus/qt/qtgui/taurusgui/utils.py
+++ b/lib/taurus/qt/qtgui/taurusgui/utils.py
@@ -33,7 +33,10 @@ __docformat__ = 'restructuredtext'
 
 import os
 import sys
+
 from lxml import etree
+from future.utils import string_types
+
 from taurus.qt.qtgui.util import ExternalAppAction
 from taurus.qt.qtgui.util import TaurusWidgetFactory
 from taurus.core.util.log import Logger
@@ -384,7 +387,7 @@ class PanelDescription(TaurusGuiComponentDescription):
         sharedDataWrite = None
         sharedDataRead = None
         model = getattr(panel.widget(), 'model', None)
-        if model is None or isinstance(model, basestring):
+        if model is None or isinstance(model, string_types):
             pass
         elif hasattr(model, '__iter__'):
             # if model is a sequence, convert to space-separated string

--- a/lib/taurus/qt/qtgui/tree/taurusdevicetree.py
+++ b/lib/taurus/qt/qtgui/tree/taurusdevicetree.py
@@ -47,6 +47,8 @@ import re
 import traceback
 from functools import partial
 
+from future.utils import string_types
+
 # @todo: icons_dev_tree is not an included or standard module.
 #        Is anybody using it? If not, the following lines should be removed and
 #        the TaurusDevTree.setStateIcon method should be cleaned
@@ -938,7 +940,7 @@ class TaurusDevTree(TaurusTreeNodeContainer, Qt.QTreeWidget, TaurusBaseWidget):
         """ Needed to do threaded expansion of the tree """
         if node is None:
             node = self.getNode()
-        if isinstance(node, (basestring, Qt.QString)):
+        if isinstance(node, string_types + (Qt.QString,)):
             name, node = str(node), self.getNode(node)
         else:
             name = self.getNodeText(node)

--- a/lib/taurus/qt/qtgui/util/taurusaction.py
+++ b/lib/taurus/qt/qtgui/util/taurusaction.py
@@ -45,6 +45,8 @@ __docformat__ = 'restructuredtext'
 import os
 import xml.dom.minidom
 
+from future.utils import string_types
+
 from taurus.external.qt import Qt
 from taurus.core.taurushelper import getSchemeFromName
 from taurus.qt.qtcore.configuration import BaseConfigurableClass
@@ -71,7 +73,7 @@ class ExternalAppAction(Qt.QAction, BaseConfigurableClass):
         :param icon: (QIcon or any other object that can be passed to QIcon creator) see :class:`Qt.QAction`
         :param parent: (QObject) The parent object
         '''
-        if isinstance(cmdargs, (basestring, Qt.QString)):
+        if isinstance(cmdargs, string_types + (Qt.QString,)):
             import shlex
             cmdargs = shlex.split(str(cmdargs))
         self.path = os.path.realpath(cmdargs and cmdargs[0] or '')
@@ -79,7 +81,7 @@ class ExternalAppAction(Qt.QAction, BaseConfigurableClass):
             text = os.path.basename(cmdargs and cmdargs[0] or '')
         if icon is None:
             icon = Qt.QIcon.fromTheme(self.DEFAULT_ICON_NAME)
-        elif isinstance(icon, basestring):
+        elif isinstance(icon, string_types):
             tmp = Qt.QIcon.fromTheme(icon)
             if not tmp.isNull():
                 icon = tmp
@@ -103,7 +105,7 @@ class ExternalAppAction(Qt.QAction, BaseConfigurableClass):
                         application. It can also be a string containing a
                         command, which will be automatically converted to a list
         '''
-        if isinstance(cmdargs, (basestring, Qt.QString)):
+        if isinstance(cmdargs, string_types + (Qt.QString,)):
             import shlex
             cmdargs = shlex.split(str(cmdargs))
         self.__cmdargs = cmdargs
@@ -119,7 +121,7 @@ class ExternalAppAction(Qt.QAction, BaseConfigurableClass):
         import subprocess
         try:
             if args is not None:
-                if isinstance(args, (basestring, Qt.QString)):
+                if isinstance(args, string_types + (Qt.QString,)):
                     import shlex
                     args = shlex.split(str(args))
                 args = self.cmdArgs() + args

--- a/lib/taurus/qt/qtgui/util/taurusactionfactory.py
+++ b/lib/taurus/qt/qtgui/util/taurusactionfactory.py
@@ -30,6 +30,8 @@ __all__ = ["ActionFactory"]
 
 __docformat__ = 'restructuredtext'
 
+from future.utils import string_types
+
 from taurus.core.util.log import Logger
 from taurus.core.util.singleton import Singleton
 from taurus.external.qt import Qt
@@ -130,7 +132,7 @@ class ActionFactory(Singleton, Logger):
             action.toggled.connect(toggled)
             action.setCheckable(True)
         if icon is not None:
-            if isinstance(icon, (str, str)):
+            if isinstance(icon, string_types):
                 icon = Qt.QIcon.fromTheme(icon)
             action.setIcon(icon)
         if shortcut is not None:

--- a/lib/taurus/test/testsuite.py
+++ b/lib/taurus/test/testsuite.py
@@ -47,6 +47,11 @@ def _filter_suite(suite, exclude_pattern, ret=None):
         ret = unittest.TestSuite()
     for e in suite:
         if isinstance(e, unittest.TestCase):
+            
+
+            if (e.__module__ == 'unittest.case'):
+                continue
+            
             if re.match(exclude_pattern, e.id()):
                 print("Excluded %s" % e.id())
                 continue

--- a/setup.py
+++ b/setup.py
@@ -57,11 +57,11 @@ provides = [
 
 install_requires = [
     'numpy>=1.1',
-    'enum34',
     'pint>=0.8',
 ]
 
 extras_require = {
+    ':python_version<"3.4"': ['enum34'],
     'taurus-qt': ['qtpy >=1.2.1',
                   # 'PyQt4 >=4.8',
                   # 'PyQt4.Qwt5 >=5.2.0',  # [Taurus-Qt-Plot]


### PR DESCRIPTION
Replaces 
```isinstance(obj,(str, unicode))
    isinstance(obj, basestring)
```
with
```
from future.utils import string_types
isinstance(obj, string_types)
```
Some backward compatibility changes are also provided.