### PR TITLE
Provides workaround for old setuptool (<20.2).

### DIFF
--- a/lib/taurus/core/util/codecs.py
+++ b/lib/taurus/core/util/codecs.py
@@ -351,7 +351,9 @@ class JSONCodec(Codec):
 
         if isinstance(data[1], buffer_types):
             data = data[0], str(data[1])
-
+        elif isinstance(data[1], bytes):
+            data = data[0], data[1].decode('utf-8')
+        
         data = json.loads(data[1])
         if ensure_ascii:
             data = self._transform_ascii(data)

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,9 @@
 
 import os
 import imp
-from setuptools import setup, find_packages
+import sys
+from distutils.version import LooseVersion
+from setuptools import setup, find_packages, __version__
 
 
 def get_release_info():
@@ -59,8 +61,16 @@ install_requires = [
     'numpy>=1.1',
     'pint>=0.8',
     'future',
-    'enum34;python_version<"3.4"',
 ]
+
+#Workaround for old setuptools
+
+if LooseVersion(__version__)<LooseVersion('20.2'):
+    if sys.version_info < (3, 4):
+        install_requires.append('enum34')
+else:
+    install_requires.append('enum34;python_version<"3.4"')
+
 
 extras_require = {
     'taurus-qt': ['qtpy >=1.2.1',

--- a/setup.py
+++ b/setup.py
@@ -59,10 +59,10 @@ install_requires = [
     'numpy>=1.1',
     'pint>=0.8',
     'future',
+    'enum34;python_version<"3.4"',
 ]
 
 extras_require = {
-    ':python_version<"3.4"': ['enum34'],
     'taurus-qt': ['qtpy >=1.2.1',
                   # 'PyQt4 >=4.8',
                   # 'PyQt4.Qwt5 >=5.2.0',  # [Taurus-Qt-Plot]


### PR DESCRIPTION
Old version of setuptools (<20.2) does not support PEP 508 (conditional requirements).
We need provide a way to check python version.
Another way is to forbid the use of old setuptools.